### PR TITLE
fix(docs): update broken dataset download links in API docs

### DIFF
--- a/src/content/docs/client-apis/python.mdx
+++ b/src/content/docs/client-apis/python.mdx
@@ -22,10 +22,10 @@ and is more convenient to use.
 Download the [CSV files](https://github.com/LadybugDB/ladybug/tree/master/dataset/demo-db/csv) used in the examples below:
 ```bash
 mkdir ./data/
-curl -L -o ./data/city.csv https://raw.githubusercontent.com/ladybugdb/ladybug/refs/heads/master/dataset/demo-db/csv/city.csv
-curl -L -o ./data/user.csv https://raw.githubusercontent.com/ladybugdb/ladybug/refs/heads/master/dataset/demo-db/csv/user.csv
-curl -L -o ./data/follows.csv https://raw.githubusercontent.com/ladybugdb/ladybug/refs/heads/master/dataset/demo-db/csv/follows.csv
-curl -L -o ./data/lives-in.csv https://raw.githubusercontent.com/ladybugdb/ladybug/refs/heads/master/dataset/demo-db/csv/lives-in.csv
+curl -L -o ./data/city.csv https://raw.githubusercontent.com/LadybugDB/dataset/refs/heads/main/demo-db/csv/city.csv
+curl -L -o ./data/user.csv https://raw.githubusercontent.com/LadybugDB/dataset/refs/heads/main/demo-db/csv/user.csv
+curl -L -o ./data/follows.csv https://raw.githubusercontent.com/LadybugDB/dataset/refs/heads/main/demo-db/csv/follows.csv
+curl -L -o ./data/lives-in.csv https://raw.githubusercontent.com/LadybugDB/dataset/refs/heads/main/demo-db/csv/lives-in.csv
 ```
 
 <Tabs syncKey="sync">

--- a/src/content/docs/get-started/index.mdx
+++ b/src/content/docs/get-started/index.mdx
@@ -97,10 +97,10 @@ Also download the example CSV files [from our GitHub repo](https://github.com/La
 
 ```bash
 mkdir ./data/
-curl -L -o ./data/city.csv https://raw.githubusercontent.com/ladybugdb/ladybug/refs/heads/master/dataset/demo-db/csv/city.csv
-curl -L -o ./data/user.csv https://raw.githubusercontent.com/ladybugdb/ladybug/refs/heads/master/dataset/demo-db/csv/user.csv
-curl -L -o ./data/follows.csv https://raw.githubusercontent.com/ladybugdb/ladybug/refs/heads/master/dataset/demo-db/csv/follows.csv
-curl -L -o ./data/lives-in.csv https://raw.githubusercontent.com/ladybugdb/ladybug/refs/heads/master/dataset/demo-db/csv/lives-in.csv
+curl -L -o ./data/city.csv https://raw.githubusercontent.com/LadybugDB/dataset/refs/heads/main/demo-db/csv/city.csv
+curl -L -o ./data/user.csv https://raw.githubusercontent.com/LadybugDB/dataset/refs/heads/main/demo-db/csv/user.csv
+curl -L -o ./data/follows.csv https://raw.githubusercontent.com/LadybugDB/dataset/refs/heads/main/demo-db/csv/follows.csv
+curl -L -o ./data/lives-in.csv https://raw.githubusercontent.com/LadybugDB/dataset/refs/heads/main/demo-db/csv/lives-in.csv
 ```
 
 In this example, we will create a graph with two node types, `User` and `City`, and two relationship types, `Follows` and `LivesIn`.


### PR DESCRIPTION
The download links in documentation are broken, this patch updates them to use the new dataset repo.

Changing all broken links matching pattern `raw.githubusercontent.com/ladybugdb/ladybug/.*/dataset/` to use the [dataset](https://github.com/LadybugDB/dataset) repo.