### PR TITLE
docs: add non-AWS endpoint guidance and list Tigris as compatible

### DIFF
--- a/src/content/docs/extensions/s3.mdx
+++ b/src/content/docs/extensions/s3.mdx
@@ -42,6 +42,22 @@ You can alternatively set the following environment variables:
 | `S3_REGION` | S3 region |
 | `S3_URL_STYLE` | S3 URL style |
 
+### Using a non-AWS endpoint
+
+To connect to an S3-compatible service (such as Cloudflare R2, MinIO, or Tigris), set `s3_endpoint` to the service's endpoint and provide credentials as usual:
+
+```cypher
+CALL s3_access_key_id='<your-key-id>';
+CALL s3_secret_access_key='<your-secret>';
+CALL s3_endpoint='<service-endpoint>';
+CALL s3_region='auto';
+```
+
+A few notes:
+
+- `s3_region` is required for request signing but is ignored by most non-AWS services. Any non-empty value works; `auto` is a common convention.
+- `s3_url_style` defaults to virtual-hosted-style. Some services (for example, MinIO in its default configuration) require path-style URLs — set `s3_url_style='path'` in that case.
+
 ### Scanning data from S3
 
 The example below shows how to scan data from a Parquet file hosted on S3.
@@ -91,7 +107,7 @@ TO 's3://lbug-datasets/saved/location.parquet';
 #### Requirements on the S3 server APIs
 
 S3 offers a standard set of APIs for read and write operations. The `httpfs` extension uses these APIs to communicate with remote storage services and thus should also work
-with other services that are compatible with the S3 API (such as [Cloudflare R2](https://www.cloudflare.com/en-gb/developer-platform/r2/)).
+with other services that are compatible with the S3 API (such as [Cloudflare R2](https://www.cloudflare.com/en-gb/developer-platform/r2/) and [Tigris](https://www.tigrisdata.com/)).
 
 The table below shows which parts of the S3 API are needed for each feature of the extension to work.
 

--- a/src/content/docs/extensions/s3.mdx
+++ b/src/content/docs/extensions/s3.mdx
@@ -56,7 +56,7 @@ CALL s3_region='auto';
 A few notes:
 
 - `s3_region` is required for request signing but is ignored by most non-AWS services. Any non-empty value works; `auto` is a common convention.
-- `s3_url_style` defaults to virtual-hosted-style. Some services (for example, MinIO in its default configuration) require path-style URLs — set `s3_url_style='path'` in that case.
+- `s3_url_style` defaults to `vhost` (virtual-hosted-style). Some services (for example, MinIO in its default configuration) require path-style URLs — set `s3_url_style='path'` in that case.
 
 ### Scanning data from S3
 


### PR DESCRIPTION
Hey there :)! I just have two small additions to `extensions/s3.mdx`:

1. Adds a short "Using a non-AWS endpoint" subsection that shows the common config pattern (`s3_endpoint` + `s3_region` + credentials) for S3-compatible services, and calls out two things the current page doesn't address:
   - `s3_region` is required for request signing but is ignored by most non-AWS services — it isn't obvious from the options table what to put there when your service doesn't have AWS-style regions
   - `s3_url_style` defaults to vhost; path-style is sometimes required (e.g. MinIO)

2. Adds Tigris next to Cloudflare R2 in the existing "compatible with the S3 API" sentence lower on the page.

Let me know if you need me to adjust anything

Thanks!