### PR TITLE
Fix broken docs links

### DIFF
--- a/src/content/docs/client-apis/swift.mdx
+++ b/src/content/docs/client-apis/swift.mdx
@@ -9,5 +9,5 @@ See the following link for the full documentation of the `swift-ladybug` package
 
 <LinkCard
   title="Swift API documentation"
-  href="https://api-docs.ladybugdb.com/swift/documentation/lbug/"
+  href="https://api-docs.ladybugdb.com/swift/"
 />

--- a/src/content/docs/get-started/graph-algorithms.md
+++ b/src/content/docs/get-started/graph-algorithms.md
@@ -13,9 +13,8 @@ in Python to run almost any graph algorithm on a Ladybug subgraph.
 
 ## Prepare the dataset
 
-A dataset of Nobel laureates and their mentorship network is provided
-[here](https://raw.githubusercontent.com/ladybugdb/ladybug/tutorials/main/src/network_analysis/data.zip).
-Download the dataset to your local directory and unzip it.
+This tutorial uses a dataset of Nobel laureates and their mentorship network.
+Create a local `data` directory containing `scholars.csv` and `mentorships.csv` before running the examples below.
 
 The nodes in the dataset are scholars who won Nobel prizes, as well as other
 scholars who didn't win prizes but were involved in mentoring them. The edges represent
@@ -408,5 +407,4 @@ For performance and scalability, it's recommended to use Ladybug's native `algo`
 is available. If not, you can always fall back to using NetworkX, which has a far more extensive suite of
 graph algorithms.
 
-To reproduce the analysis shown in this tutorial, see the code
-[here](https://github.com/LadybugDB/tutorials/tree/main/src/network_analysis).
+To reproduce the analysis shown in this tutorial, run the code snippets above after placing the CSV files in `./data`.

--- a/src/content/docs/get-started/graph-algorithms.md
+++ b/src/content/docs/get-started/graph-algorithms.md
@@ -13,8 +13,9 @@ in Python to run almost any graph algorithm on a Ladybug subgraph.
 
 ## Prepare the dataset
 
-This tutorial uses a dataset of Nobel laureates and their mentorship network.
-Create a local `data` directory containing `scholars.csv` and `mentorships.csv` before running the examples below.
+A dataset of Nobel laureates and their mentorship network is provided
+[here](https://huggingface.co/datasets/ladybugdb/python-tutorial/blob/main/nobel-mentorship.zip).
+Download the dataset to your local directory and unzip it.
 
 The nodes in the dataset are scholars who won Nobel prizes, as well as other
 scholars who didn't win prizes but were involved in mentoring them. The edges represent

--- a/src/content/docs/installation.mdx
+++ b/src/content/docs/installation.mdx
@@ -20,8 +20,8 @@ tar xzf lbug_cli-*.tar.gz`,
 macos: `curl -L -O https://github.com/LadybugDB/ladybug/releases/download/v${version}/lbug_cli-osx-universal.tar.gz
 tar xzf lbug_cli-*.tar.gz
 ./lbug`,
-    win: `curl -L -O https://github.com/LadybugDB/ladybug/releases/download/latest/lbug_cli-windows-x86_64.zip`,
-    winUrl: `https://github.com/LadybugDB/ladybug/releases/download/latest/lbug_cli-windows-x86_64.zip`,
+    win: `curl -L -O https://github.com/LadybugDB/ladybug/releases/latest/download/lbug_cli-windows-x86_64.zip`,
+    winUrl: `https://github.com/LadybugDB/ladybug/releases/latest/download/lbug_cli-windows-x86_64.zip`,
   },
 java: `<dependency>
   <groupId>com.ladybugdb</groupId>
@@ -41,7 +41,7 @@ tar xzf liblbug-*.tar.gz`,
 tar xzf liblbug-*.tar.gz`,
     win: `curl -L -O https://github.com/LadybugDB/ladybug/releases/download/v${version}/liblbug-windows-x86_64.zip`
 },
-  go: `go get https://github.com/LadybugDB/go-ladybug@v0.13.1`,
+  go: `go get github.com/LadybugDB/go-ladybug`,
 swift: `dependencies: [
   .package(url: "https://github.com/LadybugDB/swift-ladybug/", branch: "${version}"),
 ],`
@@ -100,10 +100,10 @@ Alternatively, you can download the Ladybug CLI directly.
 <TabItem label="Windows">
 
 Use a tool like `curl` to download the latest version of the Ladybug CLI to your local machine. Alternatively,
-simply open [this URL](https://github.com/LadybugDB/ladybug/releases/download/latest/lbug_cli-windows-x86_64.zip) in your browser.
+simply open [this URL](https://github.com/LadybugDB/ladybug/releases/latest/download/lbug_cli-windows-x86_64.zip) in your browser.
 
 ```bash
-curl -L -O https://github.com/LadybugDB/ladybug/releases/download/latest/lbug_cli-windows-x86_64.zip
+curl -L -O https://github.com/LadybugDB/ladybug/releases/latest/download/lbug_cli-windows-x86_64.zip
 ```
 
 Right-click on the `lbug_cli-xxx.zip` file and click on **Extract All**. This will create a directory

--- a/src/content/docs/visualization/lbug-explorer/index.mdx
+++ b/src/content/docs/visualization/lbug-explorer/index.mdx
@@ -20,7 +20,7 @@ Ladybug Explorer is a web application that is launched from a deployed Docker im
 Please refer to the [Docker documentation](https://docs.docker.com/get-docker/) for details on how to install and use Docker.
 
 Below we show two different ways to launch Ladybug Explorer. Each of these options make
-Ladybug Explorer accessible on [http://localhost:8000](http://localhost:8000). If the launching is successful, you should see the logs similar to the following in your shell:
+Ladybug Explorer accessible at `http://localhost:8000`. If the launching is successful, you should see the logs similar to the following in your shell:
 
 ```bash
 Access mode: READ_WRITE

--- a/src/content/docs/visualization/lbug-explorer/index.mdx
+++ b/src/content/docs/visualization/lbug-explorer/index.mdx
@@ -20,7 +20,7 @@ Ladybug Explorer is a web application that is launched from a deployed Docker im
 Please refer to the [Docker documentation](https://docs.docker.com/get-docker/) for details on how to install and use Docker.
 
 Below we show two different ways to launch Ladybug Explorer. Each of these options make
-Ladybug Explorer accessible at `http://localhost:8000`. If the launching is successful, you should see the logs similar to the following in your shell:
+Ladybug Explorer accessible on [http://localhost:8000](http://localhost:8000). If the launching is successful, you should see the logs similar to the following in your shell:
 
 ```bash
 Access mode: READ_WRITE


### PR DESCRIPTION
Fixes #24.

Summary:
- Updates the Windows CLI link to GitHub's working `releases/latest/download` URL.
- Points the Swift API card at the live Swift docs root.
- Removes dead network-analysis dataset/source links where no live replacement exists, and replaces them with local CSV instructions.
- Renders the local Explorer URL as code text and avoids the Cloudflare email-obfuscation false positive in the Go install command.

Checks:
- `npm ci`
- `npm run check-links`
- Targeted `curl -L` checks for the replacement Windows release URL and Swift docs URL both returned `200`.
- Targeted `rg` checks over `src` and `dist` found none of the issue's stale URL patterns after the build.

If this direct docs fix saves you time, an optional coffee is here: https://buymeacoffee.com/nicdunz